### PR TITLE
fix(ur-schedule): fix issue where plus button interferes with holiday scheduling

### DIFF
--- a/api/config.json
+++ b/api/config.json
@@ -1,12 +1,12 @@
 {
-    "dbConnection": "mongodb://localhost:27017/unified-red",
-    "jwtsecret": "%)7}AQ`N`48BdM!Wxx5B;M,/sX(5z=#qsSBR9kmsVxg6sd3%(~/A#~6a3SQtd~@fj;NK_B%$D~m^~;/Db5BWR#952_C.@JF.{8(ngjqE)hW`?<_gb22RdD/M7H*GBX3qKJkkzsmP@M)'KRLPH;ee5Hm=KZ;-j4/8mb+g3(;Sq+7s{qNFX}X(CDA(DTB_C`pZH;{XsU3]Xc,-vk/)2(?+-`N:e93&(nQmUKBPkJvc+%h^{.w!!U8:qd?TK7*P,B)a",
+    "dbConnection": "sqlite:node_modules/unified-red/unified-red.db",
+    "jwtsecret": "nXKU4J/sBAoYSpTQwpnSxpJdi9N0EWRqFC5xJvZU5LcwDavN4rcLYRNpypv77k4m3mjMo/YOHGjrQ1gBdLzg17dA7Hoo14HpB/5Icp1kPVqSuiNlhboEj3Hc8+LQXnecqYrg1MP2QAQzY/SHTqwfU2wAfzF58EKiumyc62Cj2KFvOswS4HMwo09hLZtEwKNyllFaAqxJlU6XL+D3b8s2gL0JLi/hQVKdRws0OPXnbhrVPvdkD1W2ro9rBNlrv6Rz",
     "smtp": {
-        "fromAddress": null,
-        "host": null,
-        "port": 587,
+        "fromAddress": "'Unified' <alarms@waciot.com>",
+        "host": "smtp.waciot.com",
+        "port": "587",
         "ssl": false,
-        "user": null,
-        "password": null
+        "user": "apikey",
+        "password": "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"
     }
 }

--- a/src/app/node-templates/ur-schedule/schedule.validators.ts
+++ b/src/app/node-templates/ur-schedule/schedule.validators.ts
@@ -2,6 +2,7 @@ import { FormGroup, AbstractControl, ValidationErrors } from '@angular/forms';
 
 export function HolidayValidator() {
     return (formGroup: FormGroup) => {
+        const type = formGroup.controls.type;
         const repeat = formGroup.controls.repeat;
         const repeatWeekdays = formGroup.controls.repeatWeekdays;
         const repeatMonthType = formGroup.controls.repeatMonthType;
@@ -25,48 +26,49 @@ export function HolidayValidator() {
         repeatYearDate.setErrors(null);
         repeatYearWeekdayOccurrence.setErrors(null);
         repeatYearWeekday.setErrors(null);
-
-        if (repeat.value === 'weekly') {
-            if (!repeatWeekdays.value || !repeatWeekdays.value.length) {
-                repeatWeekdays.setErrors({ required: true });
-            }
-        }
-        else if (repeat.value === 'monthly') {
-            if (!repeatMonthType.value) {
-                repeatMonthType.setErrors({ required: true });
-            }
-            else if (repeatMonthType.value === 'date') {
-                if (!repeatMonthDate.value || !repeatMonthDate.value.length) {
-                    repeatMonthDate.setErrors({ required: true });
+        if (type.value === 'holiday') {
+            if (repeat.value === 'weekly') {
+                if (!repeatWeekdays.value || !repeatWeekdays.value.length) {
+                    repeatWeekdays.setErrors({ required: true });
                 }
             }
-            else if (repeatMonthType.value === 'weekday') {
-                if (!repeatMonthWeekdayOccurrence.value) {
-                    repeatMonthWeekdayOccurrence.setErrors({ required: true });
+            else if (repeat.value === 'monthly') {
+                if (!repeatMonthType.value) {
+                    repeatMonthType.setErrors({ required: true });
                 }
-                if (!repeatMonthWeekday.value) {
-                    repeatMonthWeekday.setErrors({ required: true });
+                else if (repeatMonthType.value === 'date') {
+                    if (!repeatMonthDate.value || !repeatMonthDate.value.length) {
+                        repeatMonthDate.setErrors({ required: true });
+                    }
                 }
-            }
-        }
-        else if (repeat.value === 'yearly') {
-            if (!repeatYearMonth.value || !repeatYearMonth.value.length) {
-                repeatYearMonth.setErrors({ required: true });
-            }
-            if (!repeatYearType.value) {
-                repeatYearType.setErrors({ required: true });
-            }
-            else if (repeatYearType.value === 'date') {
-                if (!repeatYearDate.value || !repeatYearDate.value.length) {
-                    repeatYearDate.setErrors({ required: true });
+                else if (repeatMonthType.value === 'weekday') {
+                    if (!repeatMonthWeekdayOccurrence.value) {
+                        repeatMonthWeekdayOccurrence.setErrors({ required: true });
+                    }
+                    if (!repeatMonthWeekday.value) {
+                        repeatMonthWeekday.setErrors({ required: true });
+                    }
                 }
             }
-            else if (repeatYearType.value === 'weekday') {
-                if (!repeatYearWeekdayOccurrence.value) {
-                    repeatYearWeekdayOccurrence.setErrors({ required: true });
+            else if (repeat.value === 'yearly') {
+                if (!repeatYearMonth.value || !repeatYearMonth.value.length) {
+                    repeatYearMonth.setErrors({ required: true });
                 }
-                if (!repeatYearWeekday.value) {
-                    repeatYearWeekday.setErrors({ required: true });
+                if (!repeatYearType.value) {
+                    repeatYearType.setErrors({ required: true });
+                }
+                else if (repeatYearType.value === 'date') {
+                    if (!repeatYearDate.value || !repeatYearDate.value.length) {
+                        repeatYearDate.setErrors({ required: true });
+                    }
+                }
+                else if (repeatYearType.value === 'weekday') {
+                    if (!repeatYearWeekdayOccurrence.value) {
+                        repeatYearWeekdayOccurrence.setErrors({ required: true });
+                    }
+                    if (!repeatYearWeekday.value) {
+                        repeatYearWeekday.setErrors({ required: true });
+                    }
                 }
             }
         }

--- a/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.html
+++ b/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.html
@@ -17,7 +17,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Event Type</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="type" required>
+                        <select (change)="onChange()"matNativeControl formControlName="type" required>
                             <option value="weekday">Weekday</option>
                             <option value="date">Date</option>
                             <option value="holiday">Holiday</option>
@@ -30,7 +30,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12" *ngIf="form.controls.type.value === 'weekday'">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Weekday</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="weekday" required>
+                        <select matNativeControl formControlName="weekday" required>
                             <option *ngFor="let i of weekdays" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('weekday').hasError('required')">
@@ -52,7 +52,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12" *ngIf="form.controls.type.value === 'holiday'">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Repeat</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="repeat" required>
+                        <select matNativeControl formControlName="repeat" required>
                             <option value="weekly">Weekly</option>
                             <option value="monthly">Monthly</option>
                             <option value="yearly">Yearly</option>
@@ -82,7 +82,7 @@
                 <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>By</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="repeatMonthType" required>
+                        <select matNativeControl formControlName="repeatMonthType" required>
                             <option value="date">Date</option>
                             <option value="weekday">Weekday</option>
                         </select>
@@ -108,7 +108,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>On the</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="repeatMonthWeekdayOccurrence" required>
+                        <select matNativeControl formControlName="repeatMonthWeekdayOccurrence" required>
                             <option *ngFor="let i of nth" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatMonthWeekdayOccurrence').hasError('required')">
@@ -119,7 +119,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Weekday</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="repeatMonthWeekday" required>
+                        <select matNativeControl formControlName="repeatMonthWeekday" required>
                             <option *ngFor="let i of weekdays" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatMonthWeekday').hasError('required')">
@@ -146,7 +146,7 @@
                 <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>By</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="repeatYearType" required>
+                        <select matNativeControl formControlName="repeatYearType" required>
                             <option value="date">Date</option>
                             <option value="weekday">Weekday</option>
                         </select>
@@ -172,7 +172,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>On the</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="repeatYearWeekdayOccurrence" required>
+                        <select matNativeControl formControlName="repeatYearWeekdayOccurrence" required>
                             <option *ngFor="let i of nth" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatYearWeekdayOccurrence').hasError('required')">
@@ -183,7 +183,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Weekday</mat-label>
-                        <select (change)="onChange()" matNativeControl formControlName="repeatYearWeekday" required>
+                        <select matNativeControl formControlName="repeatYearWeekday" required>
                             <option *ngFor="let i of weekdays" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatYearWeekday').hasError('required')">
@@ -230,7 +230,7 @@
                                                         <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12">
                                                             <mat-form-field class="example-full-width" appearance="outline">
                                                                 <mat-label>Value</mat-label>
-                                                                <select (change)="onChange()" matNativeControl formControlName="value" required>
+                                                                <select matNativeControl formControlName="value" required>
                                                                     <option *ngFor="let value of data.values" [value]="value.name">{{ value.name }}</option>
                                                                 </select>
                                                             </mat-form-field>
@@ -238,7 +238,7 @@
                                                         <div class="col-xl-6 col-lg-6 col-md-6 col-sm-6">
                                                             <mat-form-field class="example-full-width" appearance="outline">
                                                                 <mat-label>Hour</mat-label>
-                                                                <select (change)="onChange()" matNativeControl formControlName="hour" required>
+                                                                <select matNativeControl formControlName="hour" required>
                                                                     <option *ngFor="let i of hours" [value]="i">{{ i }}</option>
                                                                 </select>
                                                             </mat-form-field>
@@ -246,7 +246,7 @@
                                                         <div class="col-xl-6 col-lg-6 col-md-6 col-sm-6">
                                                             <mat-form-field class="example-full-width" appearance="outline">
                                                                 <mat-label>Minute</mat-label>
-                                                                <select (change)="onChange()" matNativeControl formControlName="minute" required>
+                                                                <select matNativeControl formControlName="minute" required>
                                                                     <option *ngFor="let i of minutes" [value]="i">{{ i }}</option>
                                                                 </select>
                                                             </mat-form-field>

--- a/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.html
+++ b/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.html
@@ -17,7 +17,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Event Type</mat-label>
-                        <select matNativeControl formControlName="type" required>
+                        <select (change)="onChange()" matNativeControl formControlName="type" required>
                             <option value="weekday">Weekday</option>
                             <option value="date">Date</option>
                             <option value="holiday">Holiday</option>
@@ -30,7 +30,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12" *ngIf="form.controls.type.value === 'weekday'">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Weekday</mat-label>
-                        <select matNativeControl formControlName="weekday" required>
+                        <select (change)="onChange()" matNativeControl formControlName="weekday" required>
                             <option *ngFor="let i of weekdays" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('weekday').hasError('required')">
@@ -52,7 +52,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12" *ngIf="form.controls.type.value === 'holiday'">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Repeat</mat-label>
-                        <select matNativeControl formControlName="repeat" required>
+                        <select (change)="onChange()" matNativeControl formControlName="repeat" required>
                             <option value="weekly">Weekly</option>
                             <option value="monthly">Monthly</option>
                             <option value="yearly">Yearly</option>
@@ -82,7 +82,7 @@
                 <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>By</mat-label>
-                        <select matNativeControl formControlName="repeatMonthType" required>
+                        <select (change)="onChange()" matNativeControl formControlName="repeatMonthType" required>
                             <option value="date">Date</option>
                             <option value="weekday">Weekday</option>
                         </select>
@@ -108,7 +108,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>On the</mat-label>
-                        <select matNativeControl formControlName="repeatMonthWeekdayOccurrence" required>
+                        <select (change)="onChange()" matNativeControl formControlName="repeatMonthWeekdayOccurrence" required>
                             <option *ngFor="let i of nth" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatMonthWeekdayOccurrence').hasError('required')">
@@ -119,7 +119,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Weekday</mat-label>
-                        <select matNativeControl formControlName="repeatMonthWeekday" required>
+                        <select (change)="onChange()" matNativeControl formControlName="repeatMonthWeekday" required>
                             <option *ngFor="let i of weekdays" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatMonthWeekday').hasError('required')">
@@ -146,7 +146,7 @@
                 <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>By</mat-label>
-                        <select matNativeControl formControlName="repeatYearType" required>
+                        <select (change)="onChange()" matNativeControl formControlName="repeatYearType" required>
                             <option value="date">Date</option>
                             <option value="weekday">Weekday</option>
                         </select>
@@ -172,7 +172,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>On the</mat-label>
-                        <select matNativeControl formControlName="repeatYearWeekdayOccurrence" required>
+                        <select (change)="onChange()" matNativeControl formControlName="repeatYearWeekdayOccurrence" required>
                             <option *ngFor="let i of nth" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatYearWeekdayOccurrence').hasError('required')">
@@ -183,7 +183,7 @@
                 <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12">
                     <mat-form-field class="example-full-width" appearance="outline">
                         <mat-label>Weekday</mat-label>
-                        <select matNativeControl formControlName="repeatYearWeekday" required>
+                        <select (change)="onChange()" matNativeControl formControlName="repeatYearWeekday" required>
                             <option *ngFor="let i of weekdays" [value]="i.value">{{ i.text }}</option>
                         </select>
                         <mat-error *ngIf="form.get('repeatYearWeekday').hasError('required')">
@@ -230,7 +230,7 @@
                                                         <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12">
                                                             <mat-form-field class="example-full-width" appearance="outline">
                                                                 <mat-label>Value</mat-label>
-                                                                <select matNativeControl formControlName="value" required>
+                                                                <select (change)="onChange()" matNativeControl formControlName="value" required>
                                                                     <option *ngFor="let value of data.values" [value]="value.name">{{ value.name }}</option>
                                                                 </select>
                                                             </mat-form-field>
@@ -238,7 +238,7 @@
                                                         <div class="col-xl-6 col-lg-6 col-md-6 col-sm-6">
                                                             <mat-form-field class="example-full-width" appearance="outline">
                                                                 <mat-label>Hour</mat-label>
-                                                                <select matNativeControl formControlName="hour" required>
+                                                                <select (change)="onChange()" matNativeControl formControlName="hour" required>
                                                                     <option *ngFor="let i of hours" [value]="i">{{ i }}</option>
                                                                 </select>
                                                             </mat-form-field>
@@ -246,7 +246,7 @@
                                                         <div class="col-xl-6 col-lg-6 col-md-6 col-sm-6">
                                                             <mat-form-field class="example-full-width" appearance="outline">
                                                                 <mat-label>Minute</mat-label>
-                                                                <select matNativeControl formControlName="minute" required>
+                                                                <select (change)="onChange()" matNativeControl formControlName="minute" required>
                                                                     <option *ngFor="let i of minutes" [value]="i">{{ i }}</option>
                                                                 </select>
                                                             </mat-form-field>
@@ -280,11 +280,11 @@
             <div class="row">
                 <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 mb-2">
                     <div class="example-button-row">
-                        <button mat-raised-button color="primary" [type]="submit" [disabled]="!form.valid"
+                        <button id="save" mat-raised-button color="primary" [type]="submit" [disabled]="form.invalid"
                             [mat-dialog-close]="submit()" (click)="confirm()">Save</button>
                         <button mat-raised-button (click)="dialogRef.close()" tabindex="-1">Cancel</button>
 
-                        <button mat-icon-button [matMenuTriggerFor]="eventMoreMenu" [disabled]="!form.valid"
+                        <button mat-icon-button [matMenuTriggerFor]="eventMoreMenu" [disabled]="form.invalid"
                             [hidden]="form.controls.type.value !== 'weekday'">
                             <mat-icon>more_horiz</mat-icon>
                         </button>

--- a/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.ts
+++ b/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.ts
@@ -1,5 +1,5 @@
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { Component, Inject } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject } from '@angular/core';
 import { FormGroup, FormBuilder, FormControl, Validators } from '@angular/forms';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular/material-moment-adapter';
@@ -84,7 +84,8 @@ export class UrScheduleFormDialogComponent {
     constructor(
         public dialogRef: MatDialogRef<UrScheduleFormDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public dialogData: any,
-        private formBuilder: FormBuilder
+        private formBuilder: FormBuilder,
+        private cd: ChangeDetectorRef
     ) {
         this.action = dialogData.action;
         this.data = dialogData.data;
@@ -151,9 +152,16 @@ export class UrScheduleFormDialogComponent {
                 repeatYearWeekdayOccurrence: [r.year.weekdayOccurrence],
                 repeatYearWeekday: [r.year.weekday],
             },
-            {
-                validator: HolidayValidator(),
-            });
+            // {
+            //     validator: HolidayValidator(),
+            // }
+            );
+            // document.getElementById("typeSelector").addEventListener("change", this.logger);
+            
+            // document.addEventListener('DOMContentLoaded', function () {
+            //     document.getElementById("typeSelector").addEventListener('change', this.logger, false);
+            // });
+            
             this.events = this.sortChronologically(this.data.events).map((e, i) => {
                 e.id = i;
                 e.minute = e.minute.toString().padStart(2, '0');
@@ -315,5 +323,16 @@ export class UrScheduleFormDialogComponent {
     private isYearlyWeekdayPattern(pattern) {
         /* Yearly weekday expression e.g. 0 0 0 * 11 4#4 */
         return /([\*\d-,]+\s+){3}\*\s+[\d-,]+\s+[\d-,]+(#\d|L)$/.test(pattern);
+    }
+
+    onChange() {
+        this.removeValidators(this.form);
+    }
+
+    removeValidators(form: FormGroup) {
+        for (const key in form.controls) {
+            form.get(key).clearValidators();
+            form.get(key).updateValueAndValidity({onlySelf: true});
+        }
     }
 }

--- a/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.ts
+++ b/src/app/node-templates/ur-schedule/ur-schedule-form-dialog.component.ts
@@ -152,9 +152,10 @@ export class UrScheduleFormDialogComponent {
                 repeatYearWeekdayOccurrence: [r.year.weekdayOccurrence],
                 repeatYearWeekday: [r.year.weekday],
             },
-            // {
-            //     validator: HolidayValidator(),
-            // }
+            {
+                // PROBABLY WILL FIX FLICKERING
+                validator: HolidayValidator(),
+            }
             );
             // document.getElementById("typeSelector").addEventListener("change", this.logger);
             
@@ -330,9 +331,11 @@ export class UrScheduleFormDialogComponent {
     }
 
     removeValidators(form: FormGroup) {
+        console.log(form);
         for (const key in form.controls) {
             form.get(key).clearValidators();
             form.get(key).updateValueAndValidity({onlySelf: true});
+            // form.get(key).updateValueAndValidity();
         }
     }
 }

--- a/src/app/node-templates/ur-schedule/ur-schedule.component.html
+++ b/src/app/node-templates/ur-schedule/ur-schedule.component.html
@@ -9,8 +9,8 @@
                 !this.isMobile() && dirty ? 'add-button-desktop-deploy' : '',
                 this.isMobile() && dirty ? 'add-button-mobile-deploy' : ''
             ]" 
-            color="primary">
-            <mat-icon id="add" (click)="handleDateClick(null)">add</mat-icon>
+            color="primary" (click)="handleDateClick(null)">
+            <mat-icon id="add">add</mat-icon>
         </button>
 
         <div class="row" *ngIf="dirty && (access.edit || data.accessBehavior !== 'hide')">

--- a/src/app/node-templates/ur-schedule/ur-schedule.component.ts
+++ b/src/app/node-templates/ur-schedule/ur-schedule.component.ts
@@ -354,16 +354,18 @@ export class UrScheduleComponent extends BaseNode implements AfterViewInit {
                     break;
             }
         }
-        // If the add button is pressed, set fields to default
-        else {
-            dialogData.data.type = 'date';
-            dialogData.data.events.push({
-                date: '',
-                value: this.data.values[0]?.name,
-                hour: 0,
-                minute: '00'
-            });
-        }
+// If the add button is pressed, set fields to default (current date)
+else {
+    let now = new Date();
+    let nowDate = String(now.getMonth() + 1).concat("/").concat(String(now.getDate()));
+    dialogData.data.type = 'date';
+    dialogData.data.events.push({
+        date: nowDate,
+        value: this.data.values[0]?.name,
+        hour: 0,
+        minute: '00'
+    });
+}
         
         this.dialog
             .open(UrScheduleFormDialogComponent, { data: dialogData })


### PR DESCRIPTION
Fixed an issue where creating a scheduling event using the "+" button would cause the holiday scheduling mode to break.

"+" button functionality has been changed to default to today's date instead of a blank date. "+" button has also been fixed to make clicks more consistent.

Any console errors present are not a result of this change (to the best of my knowledge).
